### PR TITLE
Always include IPv6 addresses in the result of DNS lookup

### DIFF
--- a/lib/nonblocking/resolv.rb
+++ b/lib/nonblocking/resolv.rb
@@ -414,12 +414,16 @@ module Nonblocking
       end
 
       def use_ipv6? # :nodoc:
-        begin
-          list = Socket.ip_address_list
-        rescue NotImplementedError
-          return true
-        end
-        list.any? {|a| a.ipv6? && !a.ipv6_loopback? && !a.ipv6_linklocal? }
+        # This is a patch on the bug which has not fixed in the upstream "ruby/resolv" gem.
+        # ref. https://bugs.ruby-lang.org/issues/14922
+        true
+
+        # begin
+        #   list = Socket.ip_address_list
+        # rescue NotImplementedError
+        #   return true
+        # end
+        # list.any? {|a| a.ipv6? && !a.ipv6_loopback? && !a.ipv6_linklocal? }
       end
       private :use_ipv6?
 


### PR DESCRIPTION
## Detail

Currently, resolv gem includes IPv6 addresses in the result in the following case (logic simplified).

```rb
list = Socket.ip_address_list
list.any? {|a| a.ipv6? && !a.ipv6_loopback? && !a.ipv6_linklocal? }
```

This is a bug reported in [Feature #14922 Resolv getaddresses ignores AAAA records for IPv6](https://bugs.ruby-lang.org/issues/14922).

In the upstream, even though this problem is recognized and the patch PR https://github.com/ruby/resolv/pull/1 is created, it has been left for 3 years.  So I apply the patch in my forked version.

## Example when this is a problem

In Github Actions Job container (Ubuntu and macOS), this is a problem.

```rb
irb(main):002:0> list = Socket.ip_address_list
=> [#<Addrinfo: 127.0.0.1>, #<Addrinfo: 10.1.0.6>, #<Addrinfo: 172.17.0.1>, #<Addrinfo: ::1>, #<Addrinfo: fe80::222:48ff:fe1d:2c68%eth0>]

# For #<Addrinfo: ::1>
irb(main):005:0> a = Socket.ip_address_list[3]
=> #<Addrinfo: ::1>
irb(main):006:0> a.ipv6?
=> true
irb(main):007:0> a.ipv6_loopback?
=> true
irb(main):008:0> a.ipv6_linklocal?
=> false

# For #<Addrinfo: fe80::222:48ff:fe1d:2c68%eth0>
irb(main):010:0> a = Socket.ip_address_list[4]
=> #<Addrinfo: fe80::222:48ff:fe1d:2c68%eth0>
irb(main):011:0> a.ipv6?
=> true
irb(main):012:0> a.ipv6_loopback?
=> false
irb(main):013:0> a.ipv6_linklocal?
=> true
```
